### PR TITLE
Fix Composer autoload.php file loading

### DIFF
--- a/bin/loxcan
+++ b/bin/loxcan
@@ -9,7 +9,13 @@ use Symfony\Component\Console\Application;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
 
-require_once __DIR__ . '/../vendor/autoload.php';
+if (file_exists(__DIR__ . '/../vendor/autoload.php')) {
+    require_once __DIR__ . '/../vendor/autoload.php';
+} elseif (file_exists(__DIR__ . '/../../../autoload.php')) {
+    require_once __DIR__ . '/../../../autoload.php';
+} else {
+    die('Failed to load the autoload.php.');
+}
 
 $configs = [
     'commands.yaml',


### PR DESCRIPTION
下記2点の使い方で `vendor/autoload.php` を読み込むよう修正。

* プロジェクトにパッケージとして追加した場合 `composer require ***/loxcan [--dev]`
* global に追加する場合 `composer global require ***/loxcan [--dev]`